### PR TITLE
Upgraded to ASP.NET 6 beta5, OutputFormatter config

### DIFF
--- a/FrontEndWebUI/project.json
+++ b/FrontEndWebUI/project.json
@@ -3,7 +3,7 @@
     "version": "1.0.0-*",
 
     "dependencies": {
-        "Microsoft.AspNet.Server.IIS": "1.0.0-beta4",
+        "Microsoft.AspNet.Server.IIS": "1.0.0-beta5",
     },
 
     "commands": {

--- a/OrdersApi/Startup.cs
+++ b/OrdersApi/Startup.cs
@@ -24,8 +24,7 @@ namespace OrdersApi
             services.AddMvc().Configure<MvcOptions>( options =>
 			{
 				options.OutputFormatters
-					.Where( f => f.Instance is JsonOutputFormatter )
-					.Select( f => f.Instance as JsonOutputFormatter )
+					.OfType<JsonOutputFormatter>()
 					.First()
 					.SerializerSettings
 					.ContractResolver = new CamelCasePropertyNamesContractResolver();

--- a/OrdersApi/project.json
+++ b/OrdersApi/project.json
@@ -3,10 +3,10 @@
     "version": "1.0.0-*",
 
     "dependencies": {
-        "Microsoft.AspNet.Mvc": "6.0.0-beta4",
-        "Microsoft.AspNet.Server.IIS": "1.0.0-beta4",
-        "Microsoft.AspNet.Server.WebListener": "1.0.0-beta4",
-        "Microsoft.AspNet.StaticFiles": "1.0.0-beta4",
+        "Microsoft.AspNet.Mvc": "6.0.0-beta5",
+        "Microsoft.AspNet.Server.IIS": "1.0.0-beta5",
+        "Microsoft.AspNet.Server.WebListener": "1.0.0-beta5",
+        "Microsoft.AspNet.StaticFiles": "1.0.0-beta5",
         "Shared": "1.0.0-*"
     },
 

--- a/RegistryApi/Startup.cs
+++ b/RegistryApi/Startup.cs
@@ -24,8 +24,7 @@ namespace RegistryApi
 			services.AddMvc().Configure<MvcOptions>(options =>
 		   {
 			   options.OutputFormatters
-				   .Where(f => f.Instance is JsonOutputFormatter)
-				   .Select(f => f.Instance as JsonOutputFormatter)
+				   .OfType<JsonOutputFormatter>()
 				   .First()
 				   .SerializerSettings
 				   .ContractResolver = new CamelCasePropertyNamesContractResolver();

--- a/RegistryApi/project.json
+++ b/RegistryApi/project.json
@@ -3,10 +3,10 @@
     "version": "1.0.0-*",
 
     "dependencies": {
-        "Microsoft.AspNet.Mvc": "6.0.0-beta4",
-        "Microsoft.AspNet.Server.IIS": "1.0.0-beta4",
-        "Microsoft.AspNet.Server.WebListener": "1.0.0-beta4",
-        "Microsoft.AspNet.StaticFiles": "1.0.0-beta4",
+        "Microsoft.AspNet.Mvc": "6.0.0-beta5",
+        "Microsoft.AspNet.Server.IIS": "1.0.0-beta5",
+        "Microsoft.AspNet.Server.WebListener": "1.0.0-beta5",
+        "Microsoft.AspNet.StaticFiles": "1.0.0-beta5",
         "Shared": "1.0.0-*"
     },
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "sdk": {
-    "version": "1.0.0-beta4",
+    "version": "1.0.0-beta5",
     "runtime": "clr",
     "architecture": "x86"
   }


### PR DESCRIPTION
Visual Studio 2015 RTM comes bundled with beta5 which requires some updated syntax for configuring OutputFormatter
